### PR TITLE
overlays: Fix background colouring for our yaap themed icons

### DIFF
--- a/res/values-night/ic_yaap_settings_background.xml
+++ b/res/values-night/ic_yaap_settings_background.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="ic_yaap_settings_background">@android:color/black</color>
+    <color name="ic_yaap_settings_background">?android:attr/colorPrimary</color>
 </resources>


### PR DESCRIPTION
it was statically black but when we will add primary colors in future it should sync with it