### PR TITLE
Settings: Update China Connectivity Check Server to MIUI

### DIFF
--- a/res/values-zh-rCN/yaap_arrays.xml
+++ b/res/values-zh-rCN/yaap_arrays.xml
@@ -17,7 +17,7 @@
   <string-array name="connectivity_check_entries">
     <item>GrapheneOS</item>
     <item>默认 (Google)</item>
-    <item>USTC (China)</item>
+    <item>MIUI (China)</item>
     <item>禁用</item>
   </string-array>
 </resources>

--- a/res/values/yaap_arrays.xml
+++ b/res/values/yaap_arrays.xml
@@ -85,7 +85,7 @@
     <string-array name="connectivity_check_entries">
         <item>Standard (Google)</item>
         <item>GrapheneOS</item>
-        <item>USTC (China)</item>
+        <item>MIUI (China)</item>
         <item>Disabled</item>
     </string-array>
 

--- a/src/com/android/settings/network/ConnectivityCheckPreferenceController.java
+++ b/src/com/android/settings/network/ConnectivityCheckPreferenceController.java
@@ -67,11 +67,11 @@ public class ConnectivityCheckPreferenceController extends BasePreferenceControl
         OTHER_FALLBACK_INDEX, "http://grapheneos.online/generate_204"
     ));
 
-    // 204 servers for chinese users
+    // 204 servers for Chinese users
     private static final HashMap<Integer, String> CHINA_PORTAL = new HashMap<>(Map.of(
-        HTTPS_INDEX, "https://204.ustclug.org",
-        HTTP_INDEX, "http://204.ustclug.org",
-        FALLBACK_INDEX, "http://connect.rom.miui.com/generate_204",
+        HTTPS_INDEX, "https://connect.rom.miui.com/generate_204",
+        HTTP_INDEX, "http://connect.rom.miui.com/generate_204",
+        FALLBACK_INDEX, "http://connectivitycheck.platform.hicloud.com/generate_204",
         OTHER_FALLBACK_INDEX, "http://wifi.vivo.com.cn/generate_204"
     ));
 


### PR DESCRIPTION
The USTC HTTPS URL is no longer available, let's switch to the MIUI Server

Other changes:
- Update the fallback server to Huawei's connectivity check server
- Update string array