### PR TITLE
fixup! ConnectivityCheckPreferenceController: Correctly handle default

### DIFF
--- a/res/values-zh-rCN/yaap_arrays.xml
+++ b/res/values-zh-rCN/yaap_arrays.xml
@@ -15,8 +15,8 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
   <string-array name="connectivity_check_entries">
-    <item>GrapheneOS</item>
     <item>默认 (Google)</item>
+    <item>GrapheneOS</item>
     <item>MIUI (China)</item>
     <item>禁用</item>
   </string-array>


### PR DESCRIPTION
You thought you chose GrapheneOS, but actually you chose Google.
Moved `GrapheneOS` entry to its correct position in the list.

This fixup commit a252c6b1654f29fdcf5d4310ae277d9f9e6ad39a.